### PR TITLE
Update curl.php

### DIFF
--- a/curl.php
+++ b/curl.php
@@ -724,7 +724,7 @@ class GatherContent_Curl extends GatherContent_Functions {
 class GC_Walker_PageDropdown extends Walker {
 	var $tree_type = 'page';
 	var $db_fields = array ('parent' => 'post_parent', 'id' => 'ID');
-	function start_el( &$output, $page, $depth = 0, $args = array(), $id = 0, $base_name ) {
+	function start_el( &$output, $page, $depth = 0, $args = array(), $id = 0, $base_name = 'default' ) {
 		$pad = str_repeat('&nbsp;', $depth * 3);
 
 		$title = apply_filters( 'list_pages', $page->post_title, $page );


### PR DESCRIPTION
Fix: Strict Standards: Declaration of GC_Walker_PageDropdown::start_el() should be compatible with Walker::start_el(&$output, $object, $depth = 0, $args = Array, $current_object_id = 0)

Passing 'default' as base_name value. By passing `default` code will be compatible with l10n too.
