### PR TITLE
WP Proxy support

### DIFF
--- a/curl.php
+++ b/curl.php
@@ -906,7 +906,9 @@ class GatherContent_Curl extends GatherContent_Functions {
 			}
 		}
 
+		$curl_opts = apply_filters( 'gathercontent_curl_opts', $curl_opts );
 		curl_setopt_array( $session, $curl_opts );
+		$session = apply_filters( 'gathercontent_curl_session', $session, $curl_opts );
 
 		$response = curl_exec( $session );
 		$httpcode = curl_getinfo( $session, CURLINFO_HTTP_CODE );

--- a/curl.php
+++ b/curl.php
@@ -891,6 +891,21 @@ class GatherContent_Curl extends GatherContent_Functions {
 		curl_setopt( $session, CURLOPT_SSL_VERIFYPEER, true );
 		curl_setopt( $session, CURLOPT_CAINFO, $this->plugin_path . 'cacert.pem' );
 
+		// proxy support
+		$proxy = new WP_HTTP_Proxy();
+
+		if ( $proxy->is_enabled() && $proxy->send_through_proxy( $url ) ) {
+
+			curl_setopt( $session, CURLOPT_PROXYTYPE, CURLPROXY_HTTP );
+			curl_setopt( $session, CURLOPT_PROXY, $proxy->host() );
+			curl_setopt( $session, CURLOPT_PROXYPORT, $proxy->port() );
+
+			if ( $proxy->use_authentication() ) {
+				curl_setopt( $session, CURLOPT_PROXYAUTH, CURLAUTH_ANY );
+				curl_setopt( $session, CURLOPT_PROXYUSERPWD, $proxy->authentication() );
+			}
+		}
+
 		curl_setopt_array( $session, $curl_opts );
 
 		$response = curl_exec( $session );


### PR DESCRIPTION
The plugin doesn't use the default WP Http which supports a central proxy setup. It uses its own curl setup without anyway to inject proxy code.

I added some code from WP Http to support the default WP proxy. And a way to override this behavior if anyone wishes.