### PR TITLE
Make wp-cli call plugin activation/deactivation hooks

### DIFF
--- a/gathercontent.php
+++ b/gathercontent.php
@@ -718,7 +718,7 @@ class GatherContent extends GatherContent_Curl {
 		exit;
 	}
 }
-if ( is_admin() ) {
+if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 	$gc = new GatherContent;
 	register_activation_hook( __FILE__, array( &$gc, 'install' ) );
 	register_deactivation_hook( __FILE__, array( &$gc, 'uninstall' ) );


### PR DESCRIPTION
The plugin cannot be activated/deactivated using [WP CLI](http://wp-cli.org/) properly. When using wp-cli, the is_admin() check fails, so tables are never created. I just added 2 conditionals to fix this.