### PR TITLE
Make multisite install optional

### DIFF
--- a/gathercontent.php
+++ b/gathercontent.php
@@ -31,7 +31,7 @@ class GatherContent extends GatherContent_Curl {
 	function install($networkwide) {
 		global $wpdb;
 
-		if( function_exists( 'is_multisite' ) && is_multisite() ) {
+		if ( $this->multisite_install() ) {
 
 			if($networkwide) {
 				$old_blog = $wpdb->blogid;
@@ -70,7 +70,7 @@ class GatherContent extends GatherContent_Curl {
 	function uninstall($networkwide) {
 		global $wpdb;
 
-		if( function_exists( 'is_multisite' ) && is_multisite() ) {
+		if ( $this->multisite_install() ) {
 
 			if($networkwide) {
 				$old_blog = $wpdb->blogid;
@@ -93,6 +93,18 @@ class GatherContent extends GatherContent_Curl {
 		$table_name = $wpdb->prefix . 'gathercontent_items';
 
 		$wpdb->query( "DROP TABLE IF EXISTS $table_name" );
+	}
+
+	/**
+	 * Check if GatherContent should be installed all sites in a
+	 * multisite environment or not. Allows a way to override this behavior.
+	 * @return boolean true|false
+	 */
+	function multisite_install() {
+
+		$multisite = function_exists( 'is_multisite' ) && is_multisite();
+
+		return apply_filters( 'gathercontent_multisite_install', $multisite );
 	}
 
 	function init() {


### PR DESCRIPTION
We have a huge WP multisite install (1000s of sites) with mutlinetwork support using [wp-multi-network plugin](https://wordpress.org/plugins/wp-multi-network/). This plugin ends up creating a table for each of those sites.

It's due to some weird install procedures. On install, it'll create tables for the site the plugin is being activated on (rightly so). However, on second page load (or updates), it tries to add a `gathercontent_items` table for each site in multisite (using the `install($networkwide)` through `update_db_check`).

This is problematic. There's no reason why a plugin installed on one site should be creating tables for other sites.

I've added a filter to override this behavior. Alternatively, I would advise removing the install on all sites functionality.

PS: I wonder if this functionality is being added to appease the Network-wide activation in multisite. If so, just turn off `$networkwide` in `update_db_check`,