### PR TITLE
Fix auth_enabled() returning true for empty vars

### DIFF
--- a/includes/functions/functions.php
+++ b/includes/functions/functions.php
@@ -421,7 +421,7 @@ function available_mapping_post_types() {
  * @return string|bool The Auth username if enabled, or false.
  */
 function auth_enabled() {
-	if ( isset( $_SERVER['REMOTE_USER'] ) ) {
+	if ( !empty( $_SERVER['REMOTE_USER'] ) ) {
 		return $_SERVER['REMOTE_USER'];
 	}
 
@@ -430,7 +430,7 @@ function auth_enabled() {
 		'PHP_AUTH_PW',
 		'HTTP_AUTHORIZATION',
 	) as $var ) {
-		if ( isset( $_SERVER[ $var ] ) ) {
+		if ( !empty( $_SERVER[ $var ] ) ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
With isset we check if the var exists and is not null, with !empty we check that the var exists and is not false. Fixes a bug where an empty (but not null) HTTP_AUTHORIZATION var returns true, blocking initial plugin setup.