### PR TITLE
Extra comma causing syntax error during install

### DIFF
--- a/includes/classes/api.php
+++ b/includes/classes/api.php
@@ -196,7 +196,7 @@ class API extends Base {
 				'headers' => array(
 					'Accept' => 'application/vnd.gathercontent.v2+json',
 				),
-			),
+			)
 		);
 
 		// append status to the item as it was removed in the V2 APIs and needed everywhere


### PR DESCRIPTION
Hey there, just trying to install on a site running PHP 7.2.34 and encountered a syntax error. Removed the comma and good to go!