### PR TITLE
Fix undefined array key within GC SEO mapping

### DIFF
--- a/includes/classes/admin/mapping/field-types/wpseo.php
+++ b/includes/classes/admin/mapping/field-types/wpseo.php
@@ -60,7 +60,7 @@ class WPSEO extends Base implements Type {
 	protected function get_seo_options() {
 		$this->initialize_wpseo();
 
-		$options = array();
+		$options = array('all_types' => []);
 
 		global $post;
 


### PR DESCRIPTION
In php8 the unset array is causing a critical error within WordPress 5.9.2 (as default error reporting is set to E_ALL)

This fix just defines this key in advance