### PR TITLE
Fixed missing status colour on template mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Below the text box is a button that will allow you to simply save all of that in
 
 ## Changelog ##
 
+### 3.2.10 ###
+* Fixed the missing status colors on the template mapping screen.
+
 ### 3.2.9 ###
 * Added support for Bynder images, which do not include an extension in their filenames by default.
 * Importing files from attachment fields in GatherContent, will now be done using the result of the content endpoint for the item, and will no longer call the files endpoint.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gathercontent/wp-importer",
   "description": "Imports items from GatherContent to your wordpress site",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "type": "wordpress-plugin",
   "keywords": [],
   "homepage": "http://www.gathercontent.com",

--- a/includes/classes/admin/mapping-wizard.php
+++ b/includes/classes/admin/mapping-wizard.php
@@ -754,7 +754,7 @@ class Mapping_Wizard extends Base {
 			return $this->project_items[ $project_id ];
 		}
 
-		$this->project_items[ $project_id ] = $this->api()->get_project_items( $project_id, $template_id );
+		$this->project_items[ $project_id ] = $this->api()->get_project_items( $project_id, $template_id, true );
 		return $this->project_items[ $project_id ];
 	}
 

--- a/includes/classes/api.php
+++ b/includes/classes/api.php
@@ -149,12 +149,13 @@ class API extends Base {
 	 *
 	 * @link https://docs.gathercontent.com/reference/listitems
 	 *
-	 * @param  int $project_id Project ID.
-	 * @param  int $template_id Template ID.
+	 * @param  int  $project_id Project ID.
+	 * @param  int  $template_id Template ID.
+	 * @param  bool $include_status bool defaults to false.
 	 *
 	 * @return mixed             Results of request.
 	 */
-	public function get_project_items( $project_id, $template_id ) {
+	public function get_project_items( $project_id, $template_id, $include_status = false ) {
 
 		$query_params = array(
 			'template_id' => $template_id,
@@ -172,6 +173,12 @@ class API extends Base {
 			'',
 			$query_params
 		);
+
+		if ( $include_status ) {
+			foreach ($response as $i => $item) {
+				$response[ $i ]->status = (object) $this->add_status_to_item( $item );
+			}
+		}
 
 		return $response;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:       http://www.gathercontent.com
 Tags               structured content, gather content, gathercontent, import, migrate, export, mapping, production, writing, collaboration, platform, connect, link, gather, client, word, production
 Requires at least: 5.6.0
 Tested up to:      5.9.0
-Stable tag:        3.2.9
+Stable tag:        3.2.10
 License:           GPL-2.0+
 Requires PHP:	   7.0
 License URI:       https://opensource.org/licenses/GPL-2.0
@@ -64,6 +64,9 @@ Below the text box is a button that will allow you to simply save all of that in
 6. Or change the item's GatherContent status in quick-edit mode.
 
 == Changelog ==
+
+= 3.2.10 =
+* Fixed the missing status colors on the template mapping screen.
 
 = 3.2.9 =
 * Added support for Bynder images, which do not include an extension in their filenames by default.


### PR DESCRIPTION
### Description

Fixed an issue where status colors were missing on the template mapping after the user clicks on 'Review items for import'.