### PR TITLE
Supporting Multiple Workflows across Statuses in the Plugin

### DIFF
--- a/includes/views/tmpl-gc-mapping-defaults-tab-status-mappings.php
+++ b/includes/views/tmpl-gc-mapping-defaults-tab-status-mappings.php
@@ -2,12 +2,12 @@
 	<tr id="gc-status-<?php echo esc_attr( $status->id ); ?>">
 		<td>
 			<div class="gc-item-status">
-				<span class="gc-status-color 
+				<span class="gc-status-color
 				<?php
 				if ( '#ffffff' === $status->color ) :
 					?>
 					 gc-status-color-white<?php endif; ?>" style="background-color:<?php echo esc_attr( $status->color ); ?>;" data-id="<?php echo esc_attr( $status->id ); ?>"></span>
-				<?php echo esc_attr( $status->name ); ?>
+				<?php echo esc_attr( $status->display_name ); ?>
 			</div>
 		</td>
 		<td>
@@ -22,7 +22,7 @@
 			<select class="gc-default-mapping-select gc-select2" data-column="gc_status" name="<?php $this->output( 'option_base' ); ?>[gc_status][<?php echo esc_attr( $status->id ); ?>][after]"">
 				<option <# if ( ! data.gc_status[<?php echo esc_attr( $status->id ); ?>] || ! data.gc_status[<?php echo esc_attr( $status->id ); ?>].after ) { #>selected="selected"<# } #> value=""><?php _e( 'Do not change' ); ?></option>
 				<?php foreach ( $this->get( 'gc_status_options' ) as $status2 ) : ?>
-					<option data-color="<?php echo esc_attr( $status2->color ); ?>" data-description="<?php echo esc_attr( $status2->description ); ?>" <# if ( data.gc_status[<?php echo esc_attr( $status->id ); ?>] && data.gc_status[<?php echo esc_attr( $status->id ); ?>].after && '<?php echo esc_attr( $status2->id ); ?>' == data.gc_status[<?php echo esc_attr( $status->id ); ?>].after ) { #>selected="selected"<# } #> value="<?php echo esc_attr( $status2->id ); ?>"><?php echo esc_attr( $status2->name ); ?></option>
+					<option data-color="<?php echo esc_attr( $status2->color ); ?>" data-description="<?php echo esc_attr( $status2->description ); ?>" <# if ( data.gc_status[<?php echo esc_attr( $status->id ); ?>] && data.gc_status[<?php echo esc_attr( $status->id ); ?>].after && '<?php echo esc_attr( $status2->id ); ?>' == data.gc_status[<?php echo esc_attr( $status->id ); ?>].after ) { #>selected="selected"<# } #> value="<?php echo esc_attr( $status2->id ); ?>"><?php echo esc_attr( $status2->display_name ); ?></option>
 				<?php endforeach; ?>
 			</select>
 		</td>

--- a/includes/views/tmpl-gc-metabox-statuses.php
+++ b/includes/views/tmpl-gc-metabox-statuses.php
@@ -1,5 +1,5 @@
 <span class="dashicons dashicons-post-status"></span> <?php echo esc_html_x( 'Status:', 'GatherContent item status', 'gathercontent-importer' ); ?>
-<# if ( data.status && data.status.name ) { #>
+<# if ( data.status && data.status.display_name ) { #>
 <span class="gc-metabox-status">
 	<?php echo new self( 'underscore-data-status' ); ?>
 </span>

--- a/includes/views/tmpl-gc-post-column-row.php
+++ b/includes/views/tmpl-gc-post-column-row.php
@@ -1,5 +1,5 @@
 <span class="gc-status-column" data-id="{{ data.id }}" data-item="{{ data.item }}" data-mapping="{{ data.mapping }}">
-<# if ( data.status.name ) { #>
+<# if ( data.status.display_name ) { #>
 	<div class="gc-item-status">
 		<?php echo new self( 'underscore-data-status' ); ?>
 	</div>

--- a/includes/views/tmpl-gc-status-select2.php
+++ b/includes/views/tmpl-gc-status-select2.php
@@ -2,7 +2,7 @@
 	<select class="gc-default-mapping-select gc-select2" data-column="gc_status" data-id="{{ data.id }}" name="gc_status">
 		<option data-color="" data-description="" <# if ( ! data.status.id ) { #>selected="selected"<# } #> value=""><?php _e( 'Unchanged' ); ?></option>
 		<# _.each( data.statuses, function( status ) { #>
-			<option data-color="{{ status.color }}" data-description="{{ status.description }}" <# if ( status.id === data.status.id ) { #>selected="selected"<# } #> value="{{ status.id }}">{{ status.name }}</option>
+			<option data-color="{{ status.color }}" data-description="{{ status.description }}" <# if ( status.id === data.status.id ) { #>selected="selected"<# } #> value="{{ status.id }}">{{ status.display_name }}</option>
 		<# }); #>
 	</select>
 <# } else { #>

--- a/includes/views/underscore-data-status.php
+++ b/includes/views/underscore-data-status.php
@@ -1,2 +1,2 @@
 <span class="gc-status-color <# if ( '#ffffff' === data.status.color ) { #> gc-status-color-white<# } #>" style="background-color:{{ data.status.color ?? '#fff' }};" data-id="{{ data.status_id }}"></span>
-<span class="gc-status-name">{{ data.status_name ? data.status_name : ( data.status.name ?? 'N/A' ) }}</span>
+<span class="gc-status-name">{{ data.status_name ? data.status_name : ( data.status.display_name ?? 'N/A' ) }}</span>


### PR DESCRIPTION
Update plugin to use the new `display_name` value from the v0.5/projects/{projectId}/statuses endpoint. 
This field now includes the workflow the status is on, allowing support for multiple workflows in the future.

![fa8352c9-ef18-4a50-8360-0a80fab9a956](https://user-images.githubusercontent.com/1580021/203029879-f6d35886-1144-4807-bf1f-f9e7aafcabf6.jpg)
