### PR TITLE
Force the headers referer to the host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GatherContent Plugin -- Version 3.2.12 #
+# GatherContent Plugin -- Version 3.2.13 #
 
 This plugin allows you to transfer content from your GatherContent projects into your WordPress site and vice-versa.
 
@@ -46,6 +46,9 @@ Below the text box is a button that will allow you to simply save all of that in
 
 
 ## Changelog ##
+
+### 3.2.13 ###
+* Fixed issue where content and status updates were not pushing to GatherContent from the plugin
 
 ### 3.2.12 ###
 * Reformat readme.txt

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gathercontent/wp-importer",
   "description": "Imports items from GatherContent to your wordpress site",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "type": "wordpress-plugin",
   "keywords": [],
   "homepage": "http://www.gathercontent.com",

--- a/gathercontent-importer.php
+++ b/gathercontent-importer.php
@@ -3,7 +3,7 @@
  * Plugin Name:  GatherContent Plugin
  * Plugin URI:   http://www.gathercontent.com
  * Description:  Imports items from GatherContent to your wordpress site
- * Version:      3.2.12
+ * Version:      3.2.13
  * Author:       GatherContent
  * Requires PHP: 7.0
  * Author URI:   http://www.gathercontent.com
@@ -31,8 +31,8 @@
  */
 
 // Useful global constants
-define( 'GATHERCONTENT_VERSION', '3.2.12' );
-define( 'GATHERCONTENT_ENQUEUE_VERSION', '3.2.12' );
+define( 'GATHERCONTENT_VERSION', '3.2.13' );
+define( 'GATHERCONTENT_ENQUEUE_VERSION', '3.2.13' );
 define( 'GATHERCONTENT_SLUG', 'gathercontent-import' );
 define( 'GATHERCONTENT_PLUGIN', __FILE__ );
 define( 'GATHERCONTENT_URL', plugin_dir_url( __FILE__ ) );

--- a/includes/classes/api.php
+++ b/includes/classes/api.php
@@ -697,6 +697,8 @@ class API extends Base {
 			}
 		}
 
+		$args['headers']['Referer'] = $_SERVER['HTTP_HOST'];
+
 		if ( 'PUT' === $method ) {
 			$response = $this->http->request( $uri, $args );
 		} else {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gathercontent-importer",
   "title": "GatherContent Plugin",
   "description": "Imports items from GatherContent to your wordpress site",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "license": "GPLv2",
   "homepage": "http://www.gathercontent.com",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.gathercontent.com
 Tags: structured content, gather content, gathercontent, import, migrate, export, mapping, production, writing, collaboration, platform, connect, link, gather, client, word, production
 Requires at least: 5.6.0
 Tested up to: 6.0
-Stable tag: 3.2.12
+Stable tag: 3.2.13
 License: GPL-2.0+
 Requires PHP: 7.0
 License URI: https://opensource.org/licenses/GPL-2.0
@@ -64,6 +64,9 @@ Below the text box is a button that will allow you to simply save all of that in
 6. Or change the item's GatherContent status in quick-edit mode.
 
 == Changelog ==
+
+= 3.2.13 =
+* Fixed issue where content and status updates were not pushing to GatherContent from the plugin
 
 = 3.2.12 =
 * Reformat readme.txt


### PR DESCRIPTION
Using `api.gathercontent.com` is causing a CSRF 419 issue, as it looks as if the request is coming from within gathercontent.