### PR TITLE
Bump version to 3.2.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GatherContent Plugin -- Version 3.2.18 #
+# GatherContent Plugin -- Version 3.2.19 #
 
 This plugin allows you to transfer content from your GatherContent projects into your WordPress site and vice-versa.
 
@@ -46,6 +46,9 @@ Below the text box is a button that will allow you to simply save all of that in
 
 
 ## Changelog ##
+
+### 3.2.19 ###
+* Bumping version due to GitHub actions failing to deploy
 
 ### 3.2.18 ###
 * Removed references to deprecated WPSEO_Social_Admin class

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gathercontent/wp-importer",
   "description": "Imports items from GatherContent to your wordpress site",
-  "version": "3.2.18",
+  "version": "3.2.19",
   "type": "wordpress-plugin",
   "keywords": [],
   "homepage": "http://www.gathercontent.com",

--- a/gathercontent-importer.php
+++ b/gathercontent-importer.php
@@ -3,7 +3,7 @@
  * Plugin Name:  GatherContent Plugin
  * Plugin URI:   http://www.gathercontent.com
  * Description:  Imports items from GatherContent to your wordpress site
- * Version:      3.2.18
+ * Version:      3.2.19
  * Author:       GatherContent
  * Requires PHP: 7.0
  * Author URI:   http://www.gathercontent.com
@@ -31,8 +31,8 @@
  */
 
 // Useful global constants
-define( 'GATHERCONTENT_VERSION', '3.2.18' );
-define( 'GATHERCONTENT_ENQUEUE_VERSION', '3.2.18' );
+define( 'GATHERCONTENT_VERSION', '3.2.19' );
+define( 'GATHERCONTENT_ENQUEUE_VERSION', '3.2.19' );
 define( 'GATHERCONTENT_SLUG', 'gathercontent-import' );
 define( 'GATHERCONTENT_PLUGIN', __FILE__ );
 define( 'GATHERCONTENT_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gathercontent-importer",
   "title": "GatherContent Plugin",
   "description": "Imports items from GatherContent to your wordpress site",
-  "version": "3.2.18",
+  "version": "3.2.19",
   "license": "GPLv2",
   "homepage": "http://www.gathercontent.com",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.gathercontent.com
 Tags: structured content, gather content, gathercontent, import, migrate, export, mapping, production, writing, collaboration, platform, connect, link, gather, client, word, production
 Requires at least: 5.6.0
 Tested up to: 6.3
-Stable tag: 3.2.18
+Stable tag: 3.2.19
 License: GPL-2.0+
 Requires PHP: 7.0
 License URI: https://opensource.org/licenses/GPL-2.0
@@ -64,6 +64,9 @@ Below the text box is a button that will allow you to simply save all of that in
 6. Or change the item's GatherContent status in quick-edit mode.
 
 == Changelog ==
+
+= 3.2.19 =
+* Bumping version due to GitHub actions failing to deploy
 
 = 3.2.18 =
 * Removed references to deprecated WPSEO_Social_Admin class


### PR DESCRIPTION
GitHub actions were unexpectedly turned off, so the previous version failed to deploy.