### PR TITLE
[GC-4172] Move all GitHub Actions across to fixed versions

### DIFF
--- a/.github/workflows/deploy-to-wp-org.yml
+++ b/.github/workflows/deploy-to-wp-org.yml
@@ -16,7 +16,7 @@ jobs:
       # Release to WordPress.org
       - name: WordPress Plugin Deploy
         id: deploy
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@2.2.2
         with:
           generate-zip: true
         env:


### PR DESCRIPTION
Locking the `10up/action-wordpress-plugin-deploy` step to a specific version for security reasons so that changes to the `stable` branch aren't instantly applied.