### PR TITLE
[GC-4654] Build a system in which we can easily install the new Content Workflow plugin

### DIFF
--- a/gathercontent-importer.php
+++ b/gathercontent-importer.php
@@ -104,3 +104,15 @@ function gathercontent_importer_i18n() {
 	load_plugin_textdomain( $text_domain, false, plugin_basename( GATHERCONTENT_PATH ) . '/languages/' );
 }
 add_action( 'init', 'gathercontent_importer_i18n' );
+
+add_action( 'admin_init', 'cwby_check_new_plugin_isnt_activated' );
+
+function cwby_check_new_plugin_isnt_activated() {
+  // make sure to add your own plugin active check to stop looping over the wp_die call.
+  if ( is_plugin_active( 'content-workflow-by-bynder/gathercontent-importer.php' ) && is_plugin_active( 'gathercontent-import/gathercontent-importer.php' ) ) {
+    deactivate_plugins( 'gathercontent-import/gathercontent-importer.php' );
+
+    $button = '<br><a href="' . esc_attr( network_admin_url( 'plugins.php' ) ) . '" rel="nofollow ugc">Return to Plugins</a>';
+    wp_die( 'GatherContent plugin can not be activated while the Content Workflow plugin is active, and has therefore been deactivated! ' . $button );
+  }
+}

--- a/includes/classes/admin/InstallerSkin.php
+++ b/includes/classes/admin/InstallerSkin.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace GatherContent\Importer\Admin;
+
+class InstallerSkin extends \Plugin_Installer_Skin {
+	/**
+	 * Header
+	 *
+	 * @return void
+	 */
+	public function header() {
+	}
+
+	/**
+	 * Footer
+	 *
+	 * @return void
+	 */
+	public function footer() {
+	}
+
+	/**
+	 * Error
+	 *
+	 * @param array $errors Array of errors.
+	 *
+	 * @return void
+	 */
+	public function error( $errors ) {
+	}
+
+	/**
+	 * Feedback
+	 *
+	 * @param string $string Feedback string.
+	 * @param array  ...$args Array of args.
+	 *
+	 * @return void
+	 */
+	public function feedback( $string, ...$args ) {
+	}
+}

--- a/includes/classes/admin/ajax/handlers.php
+++ b/includes/classes/admin/ajax/handlers.php
@@ -7,10 +7,10 @@
 
 namespace GatherContent\Importer\Admin\Ajax;
 
+use GatherContent\Importer\Admin\InstallerSkin;
 use GatherContent\Importer\Base as Plugin_Base;
 use GatherContent\Importer\General;
 use GatherContent\Importer\Utils;
-use GatherContent\Importer\Post_Types\Template_Mappings;
 use GatherContent\Importer\Mapping_Post;
 use GatherContent\Importer\API;
 
@@ -76,6 +76,7 @@ class Handlers extends Plugin_Base {
 		add_action( 'wp_ajax_gc_wp_filter_mappings', array( $this, 'gc_wp_filter_mappings_cb' ) );
 		add_action( 'wp_ajax_gc_save_mapping_id', array( $this, 'gc_save_mapping_id_cb' ) );
 		add_action( 'wp_ajax_gc_dismiss_notice', array( $this, 'gc_dismiss_notice_cb' ) );
+		add_action('wp_ajax_gc_install_content_workflow', [$this, 'gc_install_content_workflow']);
 	}
 
 	/**
@@ -455,4 +456,52 @@ class Handlers extends Plugin_Base {
 		return wp_verify_nonce( $nonce, GATHERCONTENT_SLUG );
 	}
 
+	public function gc_install_content_workflow()
+	{
+		check_ajax_referer('gc-install-ajax-nonce', '_ajax_nonce');
+
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		try {
+			$skin = new InstallerSkin();
+			$upgrader = new \Plugin_Upgrader($skin);
+			$slug = 'query-monitor';
+			$url = 'https://api.wordpress.org/plugins/info/1.1/';
+			$url = add_query_arg(
+				[
+					'action' => 'plugin_information',
+					rawurlencode('request[slug]') => $slug,
+				],
+				$url
+			);
+			$response = wp_remote_get($url);
+
+			if ($response->status > 299) {
+				wp_send_json_error();
+			}
+
+			$response = json_decode(wp_remote_retrieve_body($response));
+			$installationLink = $response->download_link;
+			$result = $upgrader->install($installationLink);
+			if ($result === false) {
+				wp_send_json_error(['reason' => 'Failed to install', 'result' => $result]);
+			}
+
+			$matchingPlugin = array_values(array_filter(array_keys(get_plugins()), function ($plugin) use ($slug) {
+				return strpos($plugin, $slug) !== false;
+			}))[0] ?? false;
+
+			$result = activate_plugin($matchingPlugin);
+
+			if ($result === false) {
+				wp_send_json_error(['reason' => 'Failed to activate', 'result' => $result]);
+			}
+		} catch (\Throwable $exception) {
+			wp_send_json_error(['message' => $exception->getMessage()]);
+		}
+
+		wp_send_json_success();
+	}
 }

--- a/includes/classes/admin/ajax/handlers.php
+++ b/includes/classes/admin/ajax/handlers.php
@@ -467,7 +467,7 @@ class Handlers extends Plugin_Base {
 		try {
 			$skin = new InstallerSkin();
 			$upgrader = new \Plugin_Upgrader($skin);
-			$slug = 'query-monitor';
+			$slug = 'content-workflow-by-bynder';
 			$url = 'https://api.wordpress.org/plugins/info/1.1/';
 			$url = add_query_arg(
 				[
@@ -493,10 +493,28 @@ class Handlers extends Plugin_Base {
 				return strpos($plugin, $slug) !== false;
 			}))[0] ?? false;
 
+			if ($matchingPlugin === false) {
+                wp_send_json_error(['reason' => 'Failed to find plugin.', 'result' => $matchingPlugin]);
+            }
+
 			$result = activate_plugin($matchingPlugin);
 
 			if ($result === false) {
 				wp_send_json_error(['reason' => 'Failed to activate', 'result' => $result]);
+			}
+
+			$matchingPlugin = array_values(array_filter(array_keys(get_plugins()), function ($plugin) {
+				return strpos($plugin, 'gathercontent-wordpress-plugin/') !== false;
+			}))[0] ?? false;
+
+			if ($matchingPlugin === false) {
+			    wp_send_json_error(['reason' => 'Failed to find old plugin.', 'result' => $matchingPlugin]);
+			}
+
+			$result = deactivate_plugins($matchingPlugin);
+
+			if ($result === false) {
+				wp_send_json_error(['reason' => 'Failed to deactivate old plugin.', 'result' => $result]);
 			}
 		} catch (\Throwable $exception) {
 			wp_send_json_error(['message' => $exception->getMessage()]);

--- a/includes/classes/admin/ajax/handlers.php
+++ b/includes/classes/admin/ajax/handlers.php
@@ -504,7 +504,7 @@ class Handlers extends Plugin_Base {
 			}
 
 			$matchingPlugin = array_values(array_filter(array_keys(get_plugins()), function ($plugin) {
-				return strpos($plugin, 'gathercontent-wordpress-plugin/') !== false;
+				return strpos($plugin, 'gathercontent-import/') !== false;
 			}))[0] ?? false;
 
 			if ($matchingPlugin === false) {

--- a/includes/functions/functions.php
+++ b/includes/functions/functions.php
@@ -451,7 +451,7 @@ function auth_enabled() {
 add_action( 'plugins_loaded', static function() {
 	add_filter( 'admin_notices', function () {
 		$matchingPlugin = array_values(array_filter(array_keys(get_plugins()), function ($plugin) {
-			return strpos($plugin, 'query-monitor') !== false;
+			return strpos($plugin, 'content-workflow-by-bynder') !== false;
 		}))[0] ?? false;
 
 		if ($matchingPlugin && is_plugin_active($matchingPlugin)) {

--- a/includes/functions/functions.php
+++ b/includes/functions/functions.php
@@ -447,3 +447,44 @@ function auth_enabled() {
 
 	return false;
 }
+
+add_action( 'plugins_loaded', static function() {
+	add_filter( 'admin_notices', function () {
+		$matchingPlugin = array_values(array_filter(array_keys(get_plugins()), function ($plugin) {
+			return strpos($plugin, 'query-monitor') !== false;
+		}))[0] ?? false;
+
+		if ($matchingPlugin && is_plugin_active($matchingPlugin)) {
+			return;
+		}
+
+		?>
+		<div class="notice notice-error is-dismissible">
+<p><?php _e( 'The GatherContent Plugin is out of date, please install the Content Workflow plugin!', 'gathercontent-import' ); ?></p>
+			<p>
+			For a one click easy install, <a href="#" id="gc-install-content-workflow">click here</a>
+			</p>
+			<script>
+				jQuery(document).ready( function($){
+					$('#gc-install-content-workflow').on('click', function(e){
+						e.preventDefault();
+						$.ajax({
+							url: '<?php echo admin_url( 'admin-ajax.php' ) ?>',
+							type: 'POST',
+							data:{
+								_ajax_nonce: '<?php echo wp_create_nonce('gc-install-ajax-nonce')?>',
+								action: 'gc_install_content_workflow',
+							},
+							success: function( data ){
+								if (data.success) {
+									window.location.reload()
+								}
+							}
+						});
+					});
+				});
+			</script>
+</div>
+<?php
+	} );
+});


### PR DESCRIPTION
As we are looking to migrate from the old GatherContent wordpress plugin to the new Content Workflow one we need a way to make the migration process super easy. 

So what this does is add a little banner in the admin and gives the ability to install the plugin and activate it from the banner. This should hopefully reduce the friction to get the new plugin with all the new features.

We can definitely do more work in the banner to make it more appealing to do the migration.

Video demo:

https://share.zight.com/Bluvkq29